### PR TITLE
ClassGenerator skips methods which named the same as PHP keywords

### DIFF
--- a/LazyProxy/Generator/ClassGenerator.php
+++ b/LazyProxy/Generator/ClassGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Bridge\ProxyManager\LazyProxy\Generator;
+
+use ProxyManager\Generator\ClassGenerator as BaseClassGenerator;
+use Zend\Code\Generator\AbstractMemberGenerator;
+
+class ClassGenerator extends BaseClassGenerator
+{
+    /**
+     * Keywords regex
+     */
+    const KEYWORDS_REGEX = '#\b((a(bstract|nd|rray|s))|(c(a(llable|se|tch)|l(ass|one)|on(st|tinue)))|(d(e(clare|fault)|ie|o))|(e(cho|lse(if)?|mpty|nd(declare|for(each)?|if|switch|while)|val|x(it|tends)))|(f(inal|or(each)?|unction))|(g(lobal|oto))|(i(f|mplements|n(clude(_once)?|st(anceof|eadof)|terface)|sset))|(n(amespace|ew))|(p(r(i(nt|vate)|otected)|ublic))|(re(quire(_once)?|turn))|(s(tatic|witch))|(t(hrow|r(ait|y)))|(u(nset|se))|(__halt_compiler|break|list|(x)?or|var|while))\b#';
+
+    /**
+     * @inheritdoc
+     * @return array
+     * @author Vitaliy Stepanyuk <vitaliy.stepanyuk@westwing.de>
+     */
+    public function getMethods()
+    {
+        // Skip method that name is PHP keyword
+        return array_filter(parent::getMethods(), function (AbstractMemberGenerator $method) {
+            return !preg_match(self::KEYWORDS_REGEX, $method->getName());
+        });
+    }
+}

--- a/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/LazyProxy/PhpDumper/ProxyDumper.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper;
 
-use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\GeneratorStrategy\BaseGeneratorStrategy;
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolderGenerator;
+use Symfony\Bridge\ProxyManager\LazyProxy\Generator\ClassGenerator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;


### PR DESCRIPTION
For example: php-amqp extension has class \AMQPExchange with method name "declare" that you can't set as lazy service. Proxy bridge will generate wrong code
