### PR TITLE
ocramius/proxy-manager version fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/dependency-injection": "^5.0",
-        "ocramius/proxy-manager": "~2.1"
+        "ocramius/proxy-manager": "^2.1"
     },
     "require-dev": {
         "symfony/config": "^4.4|^5.0"


### PR DESCRIPTION
ocramius/proxy-manager:2.3 and above needs **php 7.4** as minimum support. 

Hence,  to maintain the support of **php 7.2.5**  in symfony/proxy-manager-bridge only ocramius/proxy-manager:**2.1.x** can be used.